### PR TITLE
Feature/#54 completed

### DIFF
--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/model/Provider.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/model/Provider.java
@@ -1,0 +1,21 @@
+package com.jasonghent98.fitness_aggregator_api.model;
+
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+// Provider.java
+@Entity
+@Table(name = "providers")
+@Data
+public class Provider {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Short id;
+    @Column(nullable=false) private String displayName;
+    @Column(nullable=false) private String authType; // 'oauth2' | 'oauth1' | 'custom'
+    private String authorizeUrl;
+    private String tokenUrl;
+    private String defaultScopes;
+    private String docsUrl;
+    @Column(nullable=false) private boolean enabled = true;
+}

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/model/Provider.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/model/Provider.java
@@ -11,7 +11,7 @@ import lombok.Data;
 public class Provider {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Short id;
-    @Column(nullable=false) private String displayName;
+    @Column(nullable=false) private String name; // 'strava | 'garmin'
     @Column(nullable=false) private String authType; // 'oauth2' | 'oauth1' | 'custom'
     private String authorizeUrl;
     private String tokenUrl;

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/model/Provider.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/model/Provider.java
@@ -9,10 +9,10 @@ import lombok.Data;
 @Table(name = "providers")
 @Data
 public class Provider {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
     private Short id;
     @Column(nullable=false) private String name; // 'strava | 'garmin'
-    @Column(nullable=false) private String authType; // 'oauth2' | 'oauth1' | 'custom'
+    @Column(nullable=false, name="auth_type") private String authType; // 'oauth2' | 'oauth1' | 'custom'
     private String authorizeUrl;
     private String tokenUrl;
     private String defaultScopes;

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/model/ProviderAccount.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/model/ProviderAccount.java
@@ -1,0 +1,59 @@
+package com.jasonghent98.fitness_aggregator_api.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// central table for all providers (strava, fitbit, etc..)
+@Entity
+@Table(
+        name = "provider_accounts",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_provider_accounts_provider_ext",
+                        columnNames = {"provider_id","provider_user_id"}),
+                @UniqueConstraint(name = "uq_provider_accounts_user_provider",
+                        columnNames = {"user_id","provider_id"})
+        },
+        indexes = {
+                @Index(name = "idx_provider_accounts_user", columnList = "user_id"),
+                @Index(name = "idx_provider_accounts_provider", columnList = "provider_id")
+        }
+)
+@Data
+public class ProviderAccount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO) // PK
+    private UUID id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "provider_id", nullable = false)
+    private Provider provider;
+
+    @Column(nullable=false, name="provider_user_id") private String providerUserId; // string safe to catch all providers
+
+    @Column(name = "access_token", nullable = false)
+    private String accessToken;
+
+    @Column(name = "refresh_token", nullable = false)
+    private String refreshToken;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+
+    @Column(name="created_at", nullable=false)
+    private Instant createdAt;
+
+    @Column(name="updated_at", nullable=false)
+    private Instant updatedAt;
+
+    @PrePersist void onCreate() { Instant now = Instant.now(); createdAt = now; updatedAt = now; }
+    @PreUpdate void onUpdate() { updatedAt = Instant.now(); }
+
+}

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/repository/ProviderAccountRepository.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/repository/ProviderAccountRepository.java
@@ -1,0 +1,13 @@
+package com.jasonghent98.fitness_aggregator_api.repository;
+
+import com.jasonghent98.fitness_aggregator_api.model.Provider;
+import com.jasonghent98.fitness_aggregator_api.model.ProviderAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ProviderAccountRepository extends JpaRepository<Provider, UUID> {
+    Optional<ProviderAccount> findByProviderAndProviderUserId(Short providerId, String providerUserId);
+    Optional<ProviderAccount> findAllByUserId(UUID userId);
+}

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/repository/ProviderRepository.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/repository/ProviderRepository.java
@@ -1,0 +1,11 @@
+package com.jasonghent98.fitness_aggregator_api.repository;
+
+import com.jasonghent98.fitness_aggregator_api.model.Provider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+// ProviderRepository.java
+public interface ProviderRepository extends JpaRepository<Provider, Short> {
+    Optional<Provider> findByName(String name); // e.g., "strava"
+}


### PR DESCRIPTION
New table provider_accounts with columns:
• id (uuid PK), user_id (uuid FK users.id), provider (enum/string ), provider_user_id (text) (unique per provider), access_token (text), refresh_token (text), expires_at (timestamptz), scope (text), created_at, updated_at.
• Unique composite index (provider, provider_user_id).
• JPA entity + Spring Data repository with:
• findByProviderAndProviderUserId(...)
• findAllByUserId(...)