### PR TITLE
Feature/#66

### DIFF
--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/config/JwtConfig.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/config/JwtConfig.java
@@ -1,6 +1,5 @@
 package com.jasonghent98.fitness_aggregator_api.config;
 import lombok.Data;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -10,15 +9,8 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "jwt")
 @Data
 public class JwtConfig {
-    @Value("${jwt.secret}")
     private String secret;
-
     private int ttlDays = 28;
-    private String issuer = "actualize-api";
+    private String issuer;
 
-    public String getSecret() { return secret; }
-
-    public int getTtlDays() { return ttlDays; }
-
-    public String getIssuer() { return issuer; }
 }

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/config/SecurityConfig.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/config/SecurityConfig.java
@@ -1,24 +1,56 @@
 package com.jasonghent98.fitness_aggregator_api.config;
 
+import com.jasonghent98.fitness_aggregator_api.security.JwtSessionFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.*;
+
+import java.util.List;
 
 @Configuration
 @Profile("dev")
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .authorizeHttpRequests(authz -> authz
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtSessionFilter jwtFilter) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        // keep routes open during dev; your controllers decide what to return
+                        .requestMatchers(
+                                "/api/strava/auth/**",
+                                "/api/fitbit/auth/**",
+                                "/api/auth/whoami",
+                                "/api/config",
+                                "/actuator/**"
+                        ).permitAll()
                         .anyRequest().permitAll()
                 )
-                .cors(cors -> {})
-                .csrf().disable()
-                .httpBasic().disable();
-        return http.build();
+                // IMPORTANT: make sure your filter actually runs
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .httpBasic(hb -> hb.disable())
+                .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration cfg = new CorsConfiguration();
+        cfg.setAllowedOrigins(List.of(
+                "https://dev.actualize.fit",
+                "http://localhost:3000"
+        ));
+        cfg.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
+        cfg.setAllowedHeaders(List.of("Content-Type","Authorization","Accept","Origin"));
+        cfg.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", cfg);
+        return source;
     }
 }

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/config/provider/fitbit/FitbitInterceptorConfig.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/config/provider/fitbit/FitbitInterceptorConfig.java
@@ -1,0 +1,20 @@
+package com.jasonghent98.fitness_aggregator_api.config.provider.fitbit;
+
+import com.jasonghent98.fitness_aggregator_api.interceptor.fitbit.FitbitTokenInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.*;
+
+@Configuration
+public class FitbitInterceptorConfig implements WebMvcConfigurer {
+
+    @Autowired
+    private FitbitTokenInterceptor fitbitTokenInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(fitbitTokenInterceptor)
+                .addPathPatterns("/api/fitbit/**")
+                .excludePathPatterns("/api/fitbit/auth/**"); // Skip login and callback
+    }
+}

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/controller/auth/SessionController.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/controller/auth/SessionController.java
@@ -23,8 +23,9 @@ public class SessionController {
     @GetMapping("/whoami")
     public ResponseEntity<?> whoami() {
         UUID id = UserContext.getUserId();
+        System.out.println(id + "from SessionController.java");
         if (id == null) {
-            return ResponseEntity.status(401).body(Map.of("userId", null));
+            return ResponseEntity.status(401).body(Map.of("authenticated", false));
         }
         return ResponseEntity.ok(Map.of("userId", id.toString()));
     }

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/integrations/fitbit/auth/FitbitTokenRefresher.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/integrations/fitbit/auth/FitbitTokenRefresher.java
@@ -1,0 +1,38 @@
+package com.jasonghent98.fitness_aggregator_api.integrations.fitbit.auth;
+
+import com.jasonghent98.fitness_aggregator_api.model.ProviderAccount;
+import com.jasonghent98.fitness_aggregator_api.integrations.TokenRefresher;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+/*
+
+-- Need to define the FitbitTokenClass for this to work --
+
+
+@Component
+public class FitbitTokenRefresher implements TokenRefresher {
+
+    private final FitbitTokenClient client; // implement similar to Strava client
+
+    public FitbitTokenRefresher(FitbitTokenClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public ProviderAccount refresh(ProviderAccount acct) {
+        var r = client.refresh(acct.getRefreshToken());
+        acct.setAccessToken(r.accessToken());
+        acct.setRefreshToken(r.refreshToken());
+        acct.setExpiresAt(Instant.now().plusSeconds(r.expiresIn()));
+        return acct;
+    }
+
+    @Override
+    public String providerName() {
+        return "fitbit";
+    }
+}
+
+ */

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/integrations/strava/auth/StravaTokenRefresher.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/integrations/strava/auth/StravaTokenRefresher.java
@@ -1,0 +1,4 @@
+package com.jasonghent98.fitness_aggregator_api.integrations.strava.auth;
+
+public class StravaTokenRefresher {
+}

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/interceptor/fitbit/FitbitTokenInterceptor.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/interceptor/fitbit/FitbitTokenInterceptor.java
@@ -1,0 +1,41 @@
+// src/main/java/.../interceptor/strava/StravaTokenInterceptor.java
+package com.jasonghent98.fitness_aggregator_api.interceptor.fitbit;
+
+import com.jasonghent98.fitness_aggregator_api.context.UserContext;
+import com.jasonghent98.fitness_aggregator_api.context.strava.StravaContext;
+import com.jasonghent98.fitness_aggregator_api.service.ProviderAccountService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class FitbitTokenInterceptor implements HandlerInterceptor {
+
+    private final ProviderAccountService providerAccountService;
+
+    public FitbitTokenInterceptor(ProviderAccountService providerAccountService) {
+        this.providerAccountService = providerAccountService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        UUID userId = UserContext.getUserId();
+        if (userId == null) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Not authenticated");
+            return false;
+        }
+        String accessToken = providerAccountService.getValidAccessToken(userId, "fitbit");
+        StravaContext.setAccessToken(accessToken);
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        StravaContext.clear();
+        UserContext.clear();
+    }
+}

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/repository/ProviderAccountRepository.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/repository/ProviderAccountRepository.java
@@ -10,4 +10,5 @@ import java.util.UUID;
 public interface ProviderAccountRepository extends JpaRepository<ProviderAccount, UUID> {
     Optional<ProviderAccount> findByProviderAndProviderUserId(Provider provider, String providerUserId);
     Optional<ProviderAccount> findAllByUserId(UUID userId);
+    Optional<ProviderAccount> findByUserIdAndProvider(UUID userId, Provider provider);
 }

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/security/JwtService.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/security/JwtService.java
@@ -2,8 +2,11 @@ package com.jasonghent98.fitness_aggregator_api.security;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.*;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.jasonghent98.fitness_aggregator_api.config.JwtConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
@@ -11,6 +14,7 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -20,6 +24,7 @@ public class JwtService {
 
     private final JwtConfig cfg;
     private final Algorithm alg;
+    private static final Logger log = LoggerFactory.getLogger(JwtService.class);
 
     public JwtService(JwtConfig cfg) {
         this.cfg = cfg;
@@ -40,12 +45,32 @@ public class JwtService {
                 .sign(alg);
     }
 
-    public UUID verify(String token) {
-        DecodedJWT jwt = JWT.require(alg)
-                .withIssuer(cfg.getIssuer())
-                .build()
-                .verify(token);
-        return UUID.fromString(jwt.getSubject());
+    public Optional<UUID> verify(String token) {
+        try {
+            DecodedJWT jwt = JWT.require(alg)
+                    .withIssuer(cfg.getIssuer())   // must match what you used in mint()
+                    .acceptLeeway(60)              // tolerate small clock skew
+                    .build()
+                    .verify(token);
+
+            String sub = jwt.getSubject();
+            UUID userId = UUID.fromString(sub); // will throw if not a UUID
+            return Optional.of(userId);
+
+        } catch (TokenExpiredException e) {
+            log.warn("JWT expired at {}", e.getExpiredOn());
+        } catch (InvalidClaimException e) {
+            log.warn("Invalid claim: {}", e.getMessage());
+        } catch (SignatureVerificationException e) {
+            log.warn("Bad signature (wrong secret/alg)");
+        } catch (AlgorithmMismatchException e) {
+            log.warn("Algorithm mismatch");
+        } catch (JWTVerificationException e) {
+            log.warn("JWT verification failed: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT subject is not a UUID");
+        }
+        return Optional.empty();
     }
 
     public String buildSessionCookie(String jwt) {

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/security/JwtSessionFilter.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/security/JwtSessionFilter.java
@@ -1,6 +1,5 @@
 package com.jasonghent98.fitness_aggregator_api.security;
 
-
 import com.jasonghent98.fitness_aggregator_api.context.UserContext;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -16,7 +15,6 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
 
-// the OncePerRequest filter class runs a filter for every incoming HTTP request
 @Component
 @Order(10)
 public class JwtSessionFilter extends OncePerRequestFilter {
@@ -27,25 +25,35 @@ public class JwtSessionFilter extends OncePerRequestFilter {
         this.jwtService = jwtService;
     }
 
-    // finds the cookie issued from this server, verifies the userId and sets it via UserContext for global state access
     @Override
     protected void doFilterInternal(
             HttpServletRequest req,
             HttpServletResponse res,
-            FilterChain chain) throws ServletException, IOException {
+            FilterChain chain
+    ) throws ServletException, IOException {
 
         try {
-            Optional<Cookie> cookie = Optional.ofNullable(req.getCookies())
-                    .flatMap(cookies -> Arrays.stream(cookies)
-                            .filter(c -> JwtService.COOKIE_NAME.equals(c.getName()))
-                            .findFirst());
+            // 1) Prefer our private header (set by Next.js server route)
+            String token = req.getHeader("X-Actualize-Session");
 
-            if (cookie.isPresent()) {
+            // 2) Fallback to cookie (direct browser → backend calls)
+            if (token == null || token.isBlank()) {
+                token = Optional.ofNullable(req.getCookies())
+                        .flatMap(cookies -> Arrays.stream(cookies)
+                                .filter(c -> JwtService.COOKIE_NAME.equals(c.getName()))
+                                .findFirst())
+                        .map(Cookie::getValue)
+                        .orElse(null);
+            }
+
+            // 3) Verify if present
+            if (token != null && !token.isBlank()) {
                 try {
-                    UUID userId = jwtService.verify(cookie.get().getValue());
-                    UserContext.setUserId(userId);
-                } catch (Exception ignored) {
-                    // invalid/expired token -> just proceed unauthenticated
+
+                    Optional<UUID> userId = jwtService.verify(token);
+                    userId.ifPresent(UserContext::setUserId);
+                } catch (Exception verifyErr) {
+                    // Invalid/expired -> just proceed unauthenticated; endpoint decides response
                 }
             }
 
@@ -57,7 +65,7 @@ public class JwtSessionFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        // If you want to skip static/assets, add exclusions here
-        return false;
+        // Skip CORS preflight and anything else you want to allow through unconditionally
+        return "OPTIONS".equalsIgnoreCase(request.getMethod());
     }
 }

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/service/ProviderAccountService.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/service/ProviderAccountService.java
@@ -18,13 +18,19 @@ public class ProviderAccountService {
     private final ProviderAccountRepository providerAccountRepo;
     private final ProviderRepository providerRepo;
     private final UserRepository userRepo;
+    private final TokenRefresherRegistry refresherRegistry;
 
-    public ProviderAccountService(ProviderAccountRepository providerAccountRepo,
-                                  ProviderRepository providerRepo,
-                                  UserRepository userRepo) {
+    public ProviderAccountService(
+            ProviderAccountRepository providerAccountRepo,
+            ProviderRepository providerRepo,
+            UserRepository userRepo,
+            TokenRefresherRegistry refresherRegistry
+    ) {
         this.providerAccountRepo = providerAccountRepo;
         this.providerRepo = providerRepo;
         this.userRepo = userRepo;
+        this.refresherRegistry = refresherRegistry;
+
     }
 
     /**
@@ -82,6 +88,30 @@ public class ProviderAccountService {
         return providerAccountRepo.save(acct);
     }
 
+    /**
+     * Gets a valid access token for user+provider + (refreshes if expired)
+     * */
+    @Transactional
+    public String getValidAccessToken(UUID userId, String providerName) {
+        Provider provider = resolveProvider(providerName);
+
+        ProviderAccount acct = providerAccountRepo
+                .findByUserIdAndProvider(userId, provider)
+                .orElseThrow(() -> new IllegalStateException(
+                        "No provider account for user=" + userId + " provider=" + provider.getName()));
+
+        if (acct.getExpiresAt() == null || acct.getExpiresAt().isBefore(Instant.now())) {
+            var refresher = refresherRegistry.get(provider.getName());
+            refresher.refresh(acct);
+            providerAccountRepo.save(acct);
+        }
+
+        return acct.getAccessToken();
+    }
+
+    /**
+     * Finds and returns the provider name or throws if not found
+     * */
     private Provider resolveProvider(String providerName) {
         return providerRepo.findByName(providerName)
                 .orElseThrow(() -> new IllegalArgumentException("Provider not found by name: " + providerName));

--- a/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/service/TokenRefresherRegistry.java
+++ b/fitness-aggregator-api/src/main/java/com/jasonghent98/fitness_aggregator_api/service/TokenRefresherRegistry.java
@@ -1,0 +1,28 @@
+// src/main/java/.../provider/TokenRefresherRegistry.java
+package com.jasonghent98.fitness_aggregator_api.service;
+
+import com.jasonghent98.fitness_aggregator_api.integrations.TokenRefresher;
+import org.springframework.stereotype.Component;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class TokenRefresherRegistry {
+    private final Map<String, TokenRefresher> byName;
+
+    public TokenRefresherRegistry(java.util.List<TokenRefresher> refreshers) {
+        this.byName = refreshers.stream()
+                .collect(Collectors.toMap(
+                        r -> r.providerName().toLowerCase(),
+                        r -> r
+                ));
+    }
+
+    public TokenRefresher get(String providerName) {
+        TokenRefresher r = byName.get(providerName.toLowerCase());
+        if (r == null) {
+            throw new IllegalArgumentException("No TokenRefresher registered for provider=" + providerName);
+        }
+        return r;
+    }
+}

--- a/scripts/dev/deploy.sh
+++ b/scripts/dev/deploy.sh
@@ -9,7 +9,7 @@ REGION="us-central1"
 
 SERVICE="dev-actualize-api"
 RUNTIME_SA="actualize-dev-api@${PROJECT}.iam.gserviceaccount.com"
-SQL_INSTANCE="actualize-dev-db"
+SQL_INSTANCE="actualize-dev-db-lite"
 
 APP_DIR="${root}/fitness-aggregator-api"
 ENV_FILE="${APP_DIR}/env.${ENV}.yaml"


### PR DESCRIPTION
- Implementing jwt session filtering at the security level, before the interceptors
- cleanup jwt config file (setters / getters removed) 
- fitbit interceptor created and configured (yet to be tested because fitbit auth routes dont yet exist) 
- fitbit token refresher initialized (getvalidaccesstoken)
- Optional<ProviderAccount> findByUserIdAndProvider(UUID userId, Provider provider) method added to ProviderAccRepo class 
- better err handling implemented for jwtservice.verify method 
- custom x-actualize-session header implemented (fixed the bug that next was interfering with Authorization header)
- renaming the sql container
